### PR TITLE
Implement einsum subscript factorization

### DIFF
--- a/einsum-derive/src/lib.rs
+++ b/einsum-derive/src/lib.rs
@@ -107,7 +107,7 @@ fn contraction_inner(subscripts: &Subscripts) -> TokenStream2 {
     for argc in 0..subscripts.inputs.len() {
         let name = arg_ident(argc);
         let mut index = Vec::new();
-        for i in subscripts.inputs[argc].indices() {
+        for i in subscripts.inputs[argc].0.indices() {
             index.push(index_ident(i));
         }
         inner_args_tt.push(quote! {
@@ -163,7 +163,7 @@ fn array_size(subscripts: &Subscripts) -> Vec<TokenStream2> {
         let mut index = Vec::new();
         let mut n_index_each = Vec::new();
         let mut def_or_assert = Vec::new();
-        for (m, i) in subscripts.inputs[argc].indices().into_iter().enumerate() {
+        for (m, i) in subscripts.inputs[argc].0.indices().into_iter().enumerate() {
             index.push(index_ident(i));
             let n = n_each_ident(argc, m);
             match n_idents.entry(i) {
@@ -212,7 +212,7 @@ fn def_einsum_fn(subscripts: &Subscripts) -> TokenStream2 {
     let dims: Vec<syn::Path> = subscripts
         .inputs
         .iter()
-        .map(|ss| dim(ss.indices().len()))
+        .map(|(ss, _pos)| dim(ss.indices().len()))
         .collect();
 
     let out_dim = dim(subscripts.output.indices().len());

--- a/einsum-solver/src/parser.rs
+++ b/einsum-solver/src/parser.rs
@@ -62,14 +62,6 @@ pub fn subscripts(input: &str) -> IResult<&str, RawSubscripts> {
     Ok((input, RawSubscripts { inputs, output }))
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum Subscript_ {
-    /// Indices without ellipsis, e.g. `ijk`
-    Indices(Vec<char>),
-    /// Indices with ellipsis, e.g. `i...j`
-    Ellipsis { start: Vec<char>, end: Vec<char> },
-}
-
 /// subscript_ = { [index] } [ [ellipsis] { [index] } ];
 pub fn subscript_(input: &str) -> IResult<&str, Subscript_> {
     let mut indices = many0(tuple((multispace0, index)).map(|(_space, c)| c));

--- a/einsum-solver/src/parser.rs
+++ b/einsum-solver/src/parser.rs
@@ -1,4 +1,4 @@
-//! Parse einsum subscripts, e.g. `ij,jk->ik`
+//! Parse einsum subscripts
 //!
 //! These parsers are implemented using [nom](https://github.com/Geal/nom),
 //! and corresponding EBNF-like schema are written in each document page.

--- a/einsum-solver/src/parser.rs
+++ b/einsum-solver/src/parser.rs
@@ -17,8 +17,8 @@ pub fn index(input: &str) -> IResult<&str, char> {
 }
 
 /// ellipsis = `...`
-pub fn ellipsis(input: &str) -> IResult<&str, Label> {
-    tag("...").map(|_| Label::Ellipsis).parse(input)
+pub fn ellipsis(input: &str) -> IResult<&str, &str> {
+    tag("...").parse(input)
 }
 
 /// subscript = { [index] } [ [ellipsis] { [index] } ];

--- a/einsum-solver/src/parser.rs
+++ b/einsum-solver/src/parser.rs
@@ -71,22 +71,6 @@ mod tests {
     use nom::Finish;
 
     #[test]
-    fn test_indices() {
-        let ans = (
-            "",
-            Subscript(vec![
-                Label::Index('i'),
-                Label::Index('j'),
-                Label::Index('k'),
-            ]),
-        );
-        assert_eq!(subscript("ijk").finish().unwrap(), ans);
-        assert_eq!(subscript("i jk").finish().unwrap(), ans);
-        assert_eq!(subscript("ij k").finish().unwrap(), ans);
-        assert_eq!(subscript("i j k").finish().unwrap(), ans);
-    }
-
-    #[test]
     fn test_subscript() {
         let (res, out) = subscript("ijk").finish().unwrap();
         assert_eq!(out, Subscript::Indices(vec!['i', 'j', 'k']));
@@ -142,10 +126,10 @@ mod tests {
                 op,
                 RawSubscripts {
                     inputs: vec![
-                        Subscript(vec![Label::Index('i'), Label::Index('j')]),
-                        Subscript(vec![Label::Index('j'), Label::Index('k')])
+                        Subscript::Indices(vec!['i', 'j']),
+                        Subscript::Indices(vec!['j', 'k'])
                     ],
-                    output: Some(Subscript(vec![Label::Index('i'), Label::Index('k')])),
+                    output: Some(Subscript::Indices(vec!['i', 'k'])),
                 }
             );
         }
@@ -167,8 +151,8 @@ mod tests {
             op,
             RawSubscripts {
                 inputs: vec![
-                    Subscript(vec![Label::Index('i'), Label::Index('j')]),
-                    Subscript(vec![Label::Index('j'), Label::Index('k')])
+                    Subscript::Indices(vec!['i', 'j']),
+                    Subscript::Indices(vec!['j', 'k'])
                 ],
                 output: None,
             }
@@ -180,10 +164,19 @@ mod tests {
             op,
             RawSubscripts {
                 inputs: vec![
-                    Subscript(vec![Label::Index('i'), Label::Ellipsis]),
-                    Subscript(vec![Label::Index('i'), Label::Ellipsis])
+                    Subscript::Ellipsis {
+                        start: vec!['i'],
+                        end: Vec::new()
+                    },
+                    Subscript::Ellipsis {
+                        start: vec!['i'],
+                        end: Vec::new()
+                    }
                 ],
-                output: Some(Subscript(vec![Label::Ellipsis]))
+                output: Some(Subscript::Ellipsis {
+                    start: Vec::new(),
+                    end: Vec::new()
+                })
             }
         );
     }

--- a/einsum-solver/src/parser.rs
+++ b/einsum-solver/src/parser.rs
@@ -58,7 +58,7 @@ impl std::str::FromStr for RawSubscripts {
 /// subscripts = [subscript] {`,` [subscript]} \[ `->` [subscript] \]
 pub fn subscripts(input: &str) -> IResult<&str, RawSubscripts> {
     let (input, _head) = multispace0(input)?;
-    let (input, inputs) = separated_list1(char(','), subscript)(input)?;
+    let (input, inputs) = separated_list1(tuple((multispace0, char(','))), subscript)(input)?;
     let (input, output) = opt(tuple((multispace0, tag("->"), multispace0, subscript))
         .map(|(_space_pre, _arrow, _space_post, output)| output))(input)?;
     Ok((input, RawSubscripts { inputs, output }))

--- a/einsum-solver/src/path.rs
+++ b/einsum-solver/src/path.rs
@@ -19,9 +19,10 @@ impl Path {
     ///
     /// ```
     /// use std::str::FromStr;
-    /// use einsum_solver::{path::Path, subscripts::Subscripts};
+    /// use einsum_solver::{path::Path, subscripts::{Subscripts, Namespace}};
     ///
-    /// let subscripts = Subscripts::from_str("ij,ji->").unwrap();
+    /// let mut names = Namespace::init();
+    /// let subscripts = Subscripts::from_raw_indices(&mut names, "ij,ji->").unwrap();
     /// let path = Path::alphabetical(subscripts);
     /// assert_eq!(path.path, &['i', 'j']);
     /// ```

--- a/einsum-solver/src/subscripts.rs
+++ b/einsum-solver/src/subscripts.rs
@@ -1,3 +1,4 @@
+//! Einsum subscripts, e.g. `ij,jk->ik`
 use crate::parser;
 use anyhow::{bail, Error, Result};
 use std::{
@@ -189,7 +190,13 @@ impl Subscripts {
         subscripts
     }
 
+    #[cfg_attr(doc, katexit::katexit)]
     /// Evaluate contracted indices
+    ///
+    /// The memorized storage is placed on the first of input.
+    /// For example, the indices of memorized storage of $j$-contraction
+    /// for `ij,jk,kl->il` will be `ik`,
+    /// and this function yields subscript `ik,kl->il` instead of `kl,ik->il`.
     ///
     /// ```
     /// use einsum_solver::subscripts::*;

--- a/einsum-solver/src/subscripts.rs
+++ b/einsum-solver/src/subscripts.rs
@@ -55,16 +55,26 @@ impl fmt::Display for Subscript {
     }
 }
 
+/// Names of tensors
+///
+/// As the crate level document explains,
+/// einsum factorization requires to track names of tensors
+/// in addition to subscripts, and this struct manages it.
+/// This works as a simple counter, which counts how many intermediate
+/// tensor denoted `out{N}` appears and issues new `out{N+1}` identifier.
+///
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct Names {
+pub struct Namespace {
     last: usize,
 }
 
-impl Names {
+impl Namespace {
+    /// Create new namespace
     pub fn init() -> Self {
-        Names { last: 0 }
+        Namespace { last: 0 }
     }
 
+    /// Issue new identifier
     pub fn new(&mut self) -> Position {
         let pos = Position::Intermidiate(self.last);
         self.last += 1;
@@ -199,7 +209,7 @@ impl Subscripts {
     /// use einsum_solver::subscripts::*;
     /// use std::str::FromStr;
     ///
-    /// let mut names = Names::init();
+    /// let mut names = Namespace::init();
     /// let base = Subscripts::from_str("ij,jk,kl->il").unwrap();
     ///
     /// // j -> k
@@ -214,7 +224,7 @@ impl Subscripts {
     /// let kj_contracted = k_contracted.contracted(&mut names, 'j').unwrap();
     /// assert_eq!(kj_contracted, Subscripts::from_str("il->il").unwrap());
     /// ```
-    pub fn contracted(&self, names: &mut Names, index: char) -> Result<Self> {
+    pub fn contracted(&self, names: &mut Namespace, index: char) -> Result<Self> {
         if !self.contraction_indices().contains(&index) {
             bail!("Unknown index: {}", index);
         }

--- a/einsum-solver/src/subscripts.rs
+++ b/einsum-solver/src/subscripts.rs
@@ -1,6 +1,6 @@
 //! Einsum subscripts, e.g. `ij,jk->ik`
 use crate::parser;
-use anyhow::{bail, Error, Result};
+use anyhow::{bail, Result};
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt,

--- a/einsum-solver/src/subscripts.rs
+++ b/einsum-solver/src/subscripts.rs
@@ -195,9 +195,19 @@ impl Subscripts {
     /// use einsum_solver::subscripts::*;
     /// use std::str::FromStr;
     ///
-    /// let subscripts = Subscripts::from_str("ij,jk,kl->il").unwrap();
-    /// let contracted = subscripts.contracted('j').unwrap();
-    /// assert_eq!(contracted, Subscripts::from_str("ik,kl->il").unwrap());
+    /// let base = Subscripts::from_str("ij,jk,kl->il").unwrap();
+    ///
+    /// // j -> k
+    /// let j_contracted = base.contracted('j').unwrap();
+    /// assert_eq!(j_contracted, Subscripts::from_str("ik,kl->il").unwrap());
+    /// let jk_contracted = j_contracted.contracted('k').unwrap();
+    /// assert_eq!(jk_contracted, Subscripts::from_str("il->il").unwrap());
+    ///
+    /// // k -> j
+    /// let k_contracted = base.contracted('k').unwrap();
+    /// assert_eq!(k_contracted, Subscripts::from_str("jl,ij->il").unwrap());
+    /// let kj_contracted = k_contracted.contracted('j').unwrap();
+    /// assert_eq!(kj_contracted, Subscripts::from_str("il->il").unwrap());
     /// ```
     pub fn contracted(&self, index: char) -> Result<Self> {
         if !self.contraction_indices().contains(&index) {

--- a/einsum-solver/src/subscripts.rs
+++ b/einsum-solver/src/subscripts.rs
@@ -63,7 +63,7 @@ impl fmt::Display for Subscript {
                 for i in start {
                     write!(f, "{}", i)?;
                 }
-                write!(f, "...")?;
+                write!(f, "___")?;
                 for i in end {
                     write!(f, "{}", i)?;
                 }

--- a/einsum-solver/src/subscripts.rs
+++ b/einsum-solver/src/subscripts.rs
@@ -71,6 +71,36 @@ impl<const N: usize> PartialEq<[char; N]> for Subscript {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Subscript_ {
+    /// Indices without ellipsis, e.g. `ijk`
+    Indices(Vec<char>),
+    /// Indices with ellipsis, e.g. `i...j`
+    Ellipsis { start: Vec<char>, end: Vec<char> },
+}
+
+impl fmt::Display for Subscript_ {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Subscript_::Indices(indices) => {
+                for i in indices {
+                    write!(f, "{}", i)?;
+                }
+            }
+            Subscript_::Ellipsis { start, end } => {
+                for i in start {
+                    write!(f, "{}", i)?;
+                }
+                write!(f, "...")?;
+                for i in end {
+                    write!(f, "{}", i)?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
 /// Einsum subscripts, e.g. `ij,jk->ik`
 #[derive(Debug, PartialEq, Eq)]
 pub struct Subscripts {

--- a/einsum-solver/src/subscripts.rs
+++ b/einsum-solver/src/subscripts.rs
@@ -42,6 +42,15 @@ pub enum Subscript {
     Ellipsis { start: Vec<char>, end: Vec<char> },
 }
 
+impl<const N: usize> PartialEq<[char; N]> for Subscript {
+    fn eq(&self, other: &[char; N]) -> bool {
+        match self {
+            Subscript::Indices(indices) => indices.eq(other),
+            _ => false,
+        }
+    }
+}
+
 impl Subscript {
     pub fn indices(&self) -> Vec<char> {
         match self {

--- a/einsum-solver/src/subscripts.rs
+++ b/einsum-solver/src/subscripts.rs
@@ -55,6 +55,15 @@ impl fmt::Display for Subscript {
     }
 }
 
+/// Which tensor the subscript specifies
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+pub enum Position {
+    /// The tensor which user inputs as N-th argument of einsum
+    User(usize),
+    /// The tensor created by einsum in its N-th step
+    Intermidiate(usize),
+}
+
 /// Einsum subscripts, e.g. `ij,jk->ik`
 #[derive(Debug, PartialEq, Eq)]
 pub struct Subscripts {

--- a/einsum-solver/src/subscripts.rs
+++ b/einsum-solver/src/subscripts.rs
@@ -7,33 +7,6 @@ use std::{
     str::FromStr,
 };
 
-/// Each subscript label
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Label {
-    /// Single index, e.g. `i` or `j`
-    Index(char),
-    /// Ellipsis `...` representing broadcast
-    Ellipsis,
-}
-
-impl fmt::Display for Label {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Label::Index(i) => write!(f, "{}", i),
-            Label::Ellipsis => write!(f, "___"),
-        }
-    }
-}
-
-impl PartialEq<char> for Label {
-    fn eq(&self, other: &char) -> bool {
-        match self {
-            Label::Index(i) => i == other,
-            Label::Ellipsis => false,
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Subscript {
     /// Indices without ellipsis, e.g. `ijk`


### PR DESCRIPTION
Split from #9, implements factorization described in #11. This PR does not modify codegen by einsum-derive, which will be done in #9 