### PR TITLE
Normalize subscript as starting from `a`

### DIFF
--- a/einsum-codegen/src/codegen/ndarray/mod.rs
+++ b/einsum-codegen/src/codegen/ndarray/mod.rs
@@ -50,7 +50,7 @@ mod test {
         let inner = quote::quote! { todo!() };
         let tt = format_block(super::function_definition(&subscripts, inner).to_string());
         insta::assert_snapshot!(tt, @r###"
-        fn ij_jk__ik<T, S0, S1>(
+        fn ab_bc__ac<T, S0, S1>(
             arg0: ndarray::ArrayBase<S0, ndarray::Ix2>,
             arg1: ndarray::ArrayBase<S1, ndarray::Ix2>,
         ) -> ndarray::Array<T, ndarray::Ix2>

--- a/einsum-codegen/src/codegen/ndarray/naive.rs
+++ b/einsum-codegen/src/codegen/ndarray/naive.rs
@@ -168,8 +168,8 @@ mod test {
         let subscripts = Subscripts::from_raw_indices(&mut namespace, "ij,jk->ik").unwrap();
         let tt = format_block(super::define_array_size(&subscripts).to_string());
         insta::assert_snapshot!(tt, @r###"
-        let (n_i, n_j) = arg0.dim();
-        let (_, n_k) = arg1.dim();
+        let (n_a, n_b) = arg0.dim();
+        let (_, n_c) = arg1.dim();
         "###);
     }
 
@@ -179,10 +179,10 @@ mod test {
         let subscripts = Subscripts::from_raw_indices(&mut namespace, "ij,jk->ik").unwrap();
         let tt = format_block(super::contraction(&subscripts).to_string());
         insta::assert_snapshot!(tt, @r###"
-        for i in 0..n_i {
-            for k in 0..n_k {
-                for j in 0..n_j {
-                    out0[(i, k)] = arg0[(i, j)] * arg1[(j, k)];
+        for a in 0..n_a {
+            for c in 0..n_c {
+                for b in 0..n_b {
+                    out0[(a, c)] = arg0[(a, b)] * arg1[(b, c)];
                 }
             }
         }
@@ -195,23 +195,23 @@ mod test {
         let subscripts = Subscripts::from_raw_indices(&mut namespace, "ij,jk->ik").unwrap();
         let tt = format_block(super::inner(&subscripts).to_string());
         insta::assert_snapshot!(tt, @r###"
-        let (n_i, n_j) = arg0.dim();
-        let (_, n_k) = arg1.dim();
+        let (n_a, n_b) = arg0.dim();
+        let (_, n_c) = arg1.dim();
         {
             let (n_0, n_1) = arg0.dim();
-            assert_eq!(n_0, n_i);
-            assert_eq!(n_1, n_j);
+            assert_eq!(n_0, n_a);
+            assert_eq!(n_1, n_b);
         }
         {
             let (n_0, n_1) = arg1.dim();
-            assert_eq!(n_0, n_j);
-            assert_eq!(n_1, n_k);
+            assert_eq!(n_0, n_b);
+            assert_eq!(n_1, n_c);
         }
-        let mut out0 = ndarray::Array::zeros((n_i, n_k));
-        for i in 0..n_i {
-            for k in 0..n_k {
-                for j in 0..n_j {
-                    out0[(i, k)] = arg0[(i, j)] * arg1[(j, k)];
+        let mut out0 = ndarray::Array::zeros((n_a, n_c));
+        for a in 0..n_a {
+            for c in 0..n_c {
+                for b in 0..n_b {
+                    out0[(a, c)] = arg0[(a, b)] * arg1[(b, c)];
                 }
             }
         }

--- a/einsum-codegen/src/path.rs
+++ b/einsum-codegen/src/path.rs
@@ -102,28 +102,28 @@ mod test {
     use super::*;
 
     #[test]
-    fn brute_force_ij_jk() -> Result<()> {
-        let path = Path::brute_force("ij,jk->ik")?;
+    fn brute_force_ab_bc() -> Result<()> {
+        let path = Path::brute_force("ab,bc->ac")?;
         assert_eq!(path.len(), 1);
-        assert_eq!(path[0].to_string(), "ij,jk->ik | arg0,arg1->out0");
+        assert_eq!(path[0].to_string(), "ab,bc->ac | arg0,arg1->out0");
         Ok(())
     }
 
     #[test]
-    fn brute_force_ij_jk_kl_l() -> Result<()> {
-        let path = Path::brute_force("ij,jk,kl,l->i")?;
+    fn brute_force_ab_bc_cd_d() -> Result<()> {
+        let path = Path::brute_force("ab,bc,cd,d->a")?;
         assert_eq!(path.len(), 3);
-        assert_eq!(path[0].to_string(), "kl,l->k | arg2,arg3->out1");
-        assert_eq!(path[1].to_string(), "k,jk->j | out1,arg1->out2");
-        assert_eq!(path[2].to_string(), "j,ij->i | out2,arg0->out0");
+        assert_eq!(path[0].to_string(), "ab,b->a | arg2,arg3->out1");
+        assert_eq!(path[1].to_string(), "a,ba->b | out1,arg1->out2");
+        assert_eq!(path[2].to_string(), "a,ba->b | out2,arg0->out0");
         Ok(())
     }
 
     #[test]
-    fn brute_force_i_i_i() -> Result<()> {
-        let path = Path::brute_force("i,i,i->")?;
+    fn brute_force_a_a_a() -> Result<()> {
+        let path = Path::brute_force("a,a,a->")?;
         assert_eq!(path.len(), 1);
-        assert_eq!(path[0].to_string(), "i,i,i-> | arg0,arg1,arg2->out0");
+        assert_eq!(path[0].to_string(), "a,a,a-> | arg0,arg1,arg2->out0");
         Ok(())
     }
 }

--- a/einsum-codegen/src/subscripts.rs
+++ b/einsum-codegen/src/subscripts.rs
@@ -318,8 +318,30 @@ impl Subscripts {
     /// assert_eq!(ss1.to_string(), "ab,bc,cd->ad | arg0,arg1,arg2->out0");
     /// assert_eq!(ss2.to_string(), "ab,bc,cd->ad | arg0,arg1,arg2->out0");
     /// ```
-    pub fn remap_indices(&mut self) -> Self {
-        todo!()
+    pub fn remap_indices(&mut self) {
+        let mut map: BTreeMap<char, u32> = BTreeMap::new();
+        let mut update = |raw: &mut RawSubscript| match raw {
+            RawSubscript::Indices(indices) => {
+                for i in indices {
+                    if !map.contains_key(i) {
+                        map.insert(*i, 'a' as u32 + map.len() as u32);
+                    }
+                    *i = char::from_u32(map[i]).unwrap();
+                }
+            }
+            RawSubscript::Ellipsis { start, end } => {
+                for i in start.iter_mut().chain(end.iter_mut()) {
+                    if !map.contains_key(i) {
+                        map.insert(*i, 'a' as u32 + map.len() as u32);
+                    }
+                    *i = char::from_u32(map[i]).unwrap();
+                }
+            }
+        };
+        for input in &mut self.inputs {
+            update(&mut input.raw);
+        }
+        update(&mut self.output.raw)
     }
 }
 

--- a/einsum-codegen/src/subscripts.rs
+++ b/einsum-codegen/src/subscripts.rs
@@ -299,6 +299,28 @@ impl Subscripts {
         write!(out, "_{}", self.output.raw).unwrap();
         out
     }
+
+    /// Remap indices as starting from `a` to distinguish same subscripts, e.g. `i,i->` and `j,j->`
+    ///
+    /// ```
+    /// use einsum_codegen::{*, parser::RawSubscript};
+    ///
+    /// let mut names = Namespace::init();
+    /// let mut ss1 = Subscripts::from_raw_indices(&mut names, "ij,jk,kl->il").unwrap();
+    /// ss1.remap_indices();
+    ///
+    /// // reset namespace
+    /// let mut names = Namespace::init();
+    /// let mut ss2 = Subscripts::from_raw_indices(&mut names, "xz,zy,yw->xw").unwrap();
+    /// ss2.remap_indices();
+    ///
+    /// assert_eq!(ss1, ss2);
+    /// assert_eq!(ss1.to_string(), "ab,bc,cd->ad | arg0,arg1,arg2->out0");
+    /// assert_eq!(ss2.to_string(), "ab,bc,cd->ad | arg0,arg1,arg2->out0");
+    /// ```
+    pub fn remap_indices(&mut self) -> Self {
+        todo!()
+    }
 }
 
 fn count_indices(inputs: &[Subscript]) -> BTreeMap<char, u32> {

--- a/einsum-derive/src/lib.rs
+++ b/einsum-derive/src/lib.rs
@@ -5,6 +5,7 @@ use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use proc_macro_error::{abort_call_site, proc_macro_error};
 use quote::quote;
+use std::collections::BTreeSet;
 use syn::parse::Parser;
 
 /// proc-macro based einsum
@@ -18,11 +19,17 @@ fn einsum2(input: TokenStream2) -> TokenStream2 {
     let (subscripts, args) = parse(input);
     let arg_ident: Vec<_> = (0..args.len()).map(Position::Arg).collect();
     let path = Path::brute_force(&subscripts).expect("Failed to construct execution path");
+    let mut defined = BTreeSet::new();
     let fn_defs: Vec<_> = path
         .iter()
-        .map(|ss| {
-            let inner = naive::inner(ss);
-            function_definition(ss, inner)
+        .filter_map(|ss| {
+            if defined.contains(&ss.escaped_ident()) {
+                None
+            } else {
+                defined.insert(ss.escaped_ident());
+                let inner = naive::inner(ss);
+                Some(function_definition(ss, inner))
+            }
         })
         .collect();
     let out = path.output();
@@ -158,37 +165,6 @@ mod test {
                     }
                 }
                 out1
-            }
-            fn ab_bc__ac<T, S0, S1>(
-                out1: ndarray::ArrayBase<S0, ndarray::Ix2>,
-                arg2: ndarray::ArrayBase<S1, ndarray::Ix2>,
-            ) -> ndarray::Array<T, ndarray::Ix2>
-            where
-                T: ndarray::LinalgScalar,
-                S0: ndarray::Data<Elem = T>,
-                S1: ndarray::Data<Elem = T>,
-            {
-                let (n_a, n_b) = out1.dim();
-                let (_, n_c) = arg2.dim();
-                {
-                    let (n_0, n_1) = out1.dim();
-                    assert_eq!(n_0, n_a);
-                    assert_eq!(n_1, n_b);
-                }
-                {
-                    let (n_0, n_1) = arg2.dim();
-                    assert_eq!(n_0, n_b);
-                    assert_eq!(n_1, n_c);
-                }
-                let mut out0 = ndarray::Array::zeros((n_a, n_c));
-                for a in 0..n_a {
-                    for c in 0..n_c {
-                        for b in 0..n_b {
-                            out0[(a, c)] = out1[(a, b)] * arg2[(b, c)];
-                        }
-                    }
-                }
-                out0
             }
             let arg0 = x;
             let arg1 = y;

--- a/einsum-derive/src/lib.rs
+++ b/einsum-derive/src/lib.rs
@@ -69,21 +69,21 @@ mod test {
 
     #[test]
     fn test_parse() {
-        let input = TokenStream2::from_str(r#""ij,jk->ik", a, b"#).unwrap();
+        let input = TokenStream2::from_str(r#""ab,bc->ac", x, y"#).unwrap();
         let (subscripts, exprs) = parse(input);
-        assert_eq!(subscripts, "ij,jk->ik");
+        assert_eq!(subscripts, "ab,bc->ac");
         assert_eq!(exprs.len(), 2);
-        assert_eq!(exprs[0], syn::parse_str::<syn::Expr>("a").unwrap());
-        assert_eq!(exprs[1], syn::parse_str::<syn::Expr>("b").unwrap());
+        assert_eq!(exprs[0], syn::parse_str::<syn::Expr>("x").unwrap());
+        assert_eq!(exprs[1], syn::parse_str::<syn::Expr>("y").unwrap());
     }
 
     #[test]
-    fn einsum_ij_jk() {
-        let input = TokenStream2::from_str(r#""ij,jk->ik", a, b"#).unwrap();
+    fn einsum_ab_bc() {
+        let input = TokenStream2::from_str(r#""ab,bc->ac", x, y"#).unwrap();
         let tt = format_block(einsum2(input).to_string());
         insta::assert_snapshot!(tt, @r###"
         {
-            fn ij_jk__ik<T, S0, S1>(
+            fn ab_bc__ac<T, S0, S1>(
                 arg0: ndarray::ArrayBase<S0, ndarray::Ix2>,
                 arg1: ndarray::ArrayBase<S1, ndarray::Ix2>,
             ) -> ndarray::Array<T, ndarray::Ix2>
@@ -92,43 +92,43 @@ mod test {
                 S0: ndarray::Data<Elem = T>,
                 S1: ndarray::Data<Elem = T>,
             {
-                let (n_i, n_j) = arg0.dim();
-                let (_, n_k) = arg1.dim();
+                let (n_a, n_b) = arg0.dim();
+                let (_, n_c) = arg1.dim();
                 {
                     let (n_0, n_1) = arg0.dim();
-                    assert_eq!(n_0, n_i);
-                    assert_eq!(n_1, n_j);
+                    assert_eq!(n_0, n_a);
+                    assert_eq!(n_1, n_b);
                 }
                 {
                     let (n_0, n_1) = arg1.dim();
-                    assert_eq!(n_0, n_j);
-                    assert_eq!(n_1, n_k);
+                    assert_eq!(n_0, n_b);
+                    assert_eq!(n_1, n_c);
                 }
-                let mut out0 = ndarray::Array::zeros((n_i, n_k));
-                for i in 0..n_i {
-                    for k in 0..n_k {
-                        for j in 0..n_j {
-                            out0[(i, k)] = arg0[(i, j)] * arg1[(j, k)];
+                let mut out0 = ndarray::Array::zeros((n_a, n_c));
+                for a in 0..n_a {
+                    for c in 0..n_c {
+                        for b in 0..n_b {
+                            out0[(a, c)] = arg0[(a, b)] * arg1[(b, c)];
                         }
                     }
                 }
                 out0
             }
-            let arg0 = a;
-            let arg1 = b;
-            let out0 = ij_jk__ik(arg0, arg1);
+            let arg0 = x;
+            let arg1 = y;
+            let out0 = ab_bc__ac(arg0, arg1);
             out0
         }
         "###);
     }
 
     #[test]
-    fn einsum_ij_jk_kl() {
-        let input = TokenStream2::from_str(r#""ij,jk,kl->il", a, b, c"#).unwrap();
+    fn einsum_ab_bc_cd() {
+        let input = TokenStream2::from_str(r#""ab,bc,cd->ad", x, y, z"#).unwrap();
         let tt = format_block(einsum2(input).to_string());
         insta::assert_snapshot!(tt, @r###"
         {
-            fn ij_jk__ik<T, S0, S1>(
+            fn ab_bc__ac<T, S0, S1>(
                 arg0: ndarray::ArrayBase<S0, ndarray::Ix2>,
                 arg1: ndarray::ArrayBase<S1, ndarray::Ix2>,
             ) -> ndarray::Array<T, ndarray::Ix2>
@@ -137,29 +137,29 @@ mod test {
                 S0: ndarray::Data<Elem = T>,
                 S1: ndarray::Data<Elem = T>,
             {
-                let (n_i, n_j) = arg0.dim();
-                let (_, n_k) = arg1.dim();
+                let (n_a, n_b) = arg0.dim();
+                let (_, n_c) = arg1.dim();
                 {
                     let (n_0, n_1) = arg0.dim();
-                    assert_eq!(n_0, n_i);
-                    assert_eq!(n_1, n_j);
+                    assert_eq!(n_0, n_a);
+                    assert_eq!(n_1, n_b);
                 }
                 {
                     let (n_0, n_1) = arg1.dim();
-                    assert_eq!(n_0, n_j);
-                    assert_eq!(n_1, n_k);
+                    assert_eq!(n_0, n_b);
+                    assert_eq!(n_1, n_c);
                 }
-                let mut out1 = ndarray::Array::zeros((n_i, n_k));
-                for i in 0..n_i {
-                    for k in 0..n_k {
-                        for j in 0..n_j {
-                            out1[(i, k)] = arg0[(i, j)] * arg1[(j, k)];
+                let mut out1 = ndarray::Array::zeros((n_a, n_c));
+                for a in 0..n_a {
+                    for c in 0..n_c {
+                        for b in 0..n_b {
+                            out1[(a, c)] = arg0[(a, b)] * arg1[(b, c)];
                         }
                     }
                 }
                 out1
             }
-            fn ik_kl__il<T, S0, S1>(
+            fn ab_bc__ac<T, S0, S1>(
                 out1: ndarray::ArrayBase<S0, ndarray::Ix2>,
                 arg2: ndarray::ArrayBase<S1, ndarray::Ix2>,
             ) -> ndarray::Array<T, ndarray::Ix2>
@@ -168,33 +168,33 @@ mod test {
                 S0: ndarray::Data<Elem = T>,
                 S1: ndarray::Data<Elem = T>,
             {
-                let (n_i, n_k) = out1.dim();
-                let (_, n_l) = arg2.dim();
+                let (n_a, n_b) = out1.dim();
+                let (_, n_c) = arg2.dim();
                 {
                     let (n_0, n_1) = out1.dim();
-                    assert_eq!(n_0, n_i);
-                    assert_eq!(n_1, n_k);
+                    assert_eq!(n_0, n_a);
+                    assert_eq!(n_1, n_b);
                 }
                 {
                     let (n_0, n_1) = arg2.dim();
-                    assert_eq!(n_0, n_k);
-                    assert_eq!(n_1, n_l);
+                    assert_eq!(n_0, n_b);
+                    assert_eq!(n_1, n_c);
                 }
-                let mut out0 = ndarray::Array::zeros((n_i, n_l));
-                for i in 0..n_i {
-                    for l in 0..n_l {
-                        for k in 0..n_k {
-                            out0[(i, l)] = out1[(i, k)] * arg2[(k, l)];
+                let mut out0 = ndarray::Array::zeros((n_a, n_c));
+                for a in 0..n_a {
+                    for c in 0..n_c {
+                        for b in 0..n_b {
+                            out0[(a, c)] = out1[(a, b)] * arg2[(b, c)];
                         }
                     }
                 }
                 out0
             }
-            let arg0 = a;
-            let arg1 = b;
-            let arg2 = c;
-            let out1 = ij_jk__ik(arg0, arg1);
-            let out0 = ik_kl__il(out1, arg2);
+            let arg0 = x;
+            let arg1 = y;
+            let arg2 = z;
+            let out1 = ab_bc__ac(arg0, arg1);
+            let out0 = ab_bc__ac(out1, arg2);
             out0
         }
         "###);


### PR DESCRIPTION
First step for #22 

Remap indices as starting from `a` to distinguish same subscripts, e.g. `i,i->` and `j,j->` are both mapped to `a,a->`.