### PR TITLE
Call GEMM for `ab,bc->ac` and DOT for `a,a->`

### DIFF
--- a/einsum-codegen/src/codegen/ndarray/mod.rs
+++ b/einsum-codegen/src/codegen/ndarray/mod.rs
@@ -1,14 +1,63 @@
 //! For [ndarray](https://crates.io/crates/ndarray) crate
 
-pub mod naive;
+mod naive;
+
+pub use naive::naive;
 
 use crate::subscripts::Subscripts;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
+use std::collections::HashSet;
 
 fn dim(n: usize) -> syn::Path {
     let ix = quote::format_ident!("Ix{}", n);
     syn::parse_quote! { ndarray::#ix }
+}
+
+pub fn n_ident(i: char) -> syn::Ident {
+    quote::format_ident!("n_{}", i)
+}
+
+/// Define the index size identifiers, e.g. `n_i`
+fn define_array_size(subscripts: &Subscripts) -> TokenStream2 {
+    let mut appeared: HashSet<char> = HashSet::new();
+    let mut tt = Vec::new();
+    for arg in subscripts.inputs.iter() {
+        let n_ident: Vec<syn::Ident> = arg
+            .indices()
+            .into_iter()
+            .map(|i| {
+                if appeared.contains(&i) {
+                    quote::format_ident!("_")
+                } else {
+                    appeared.insert(i);
+                    n_ident(i)
+                }
+            })
+            .collect();
+        tt.push(quote! {
+            let (#(#n_ident),*) = #arg.dim();
+        });
+    }
+    quote! { #(#tt)* }
+}
+
+/// Generate `assert_eq!` to check the size of user input tensors
+fn array_size_asserts(subscripts: &Subscripts) -> TokenStream2 {
+    let mut tt = Vec::new();
+    for arg in &subscripts.inputs {
+        // local variable, e.g. `n_2`
+        let n_each: Vec<_> = (0..arg.indices().len())
+            .map(|m| quote::format_ident!("n_{}", m))
+            .collect();
+        // size of index defined previously, e.g. `n_i`
+        let n: Vec<_> = arg.indices().into_iter().map(n_ident).collect();
+        tt.push(quote! {
+            let (#(#n_each),*) = #arg.dim();
+            #(assert_eq!(#n_each, #n);)*
+        });
+    }
+    quote! { #({ #tt })* }
 }
 
 /// Generate einsum function definition
@@ -26,6 +75,9 @@ pub fn function_definition(subscripts: &Subscripts, inner: TokenStream2) -> Toke
 
     let out_dim = dim(subscripts.output.indices().len());
 
+    let array_size = define_array_size(subscripts);
+    let array_size_asserts = array_size_asserts(subscripts);
+
     quote! {
         fn #fn_name<T, #(#storages),*>(
             #( #args: ndarray::ArrayBase<#storages, #dims> ),*
@@ -34,6 +86,9 @@ pub fn function_definition(subscripts: &Subscripts, inner: TokenStream2) -> Toke
             T: ndarray::LinalgScalar,
             #( #storages: ndarray::Data<Elem = T> ),*
         {
+            #array_size
+            #array_size_asserts
+
             #inner
         }
     }
@@ -42,6 +97,17 @@ pub fn function_definition(subscripts: &Subscripts, inner: TokenStream2) -> Toke
 #[cfg(test)]
 mod test {
     use crate::{codegen::format_block, *};
+
+    #[test]
+    fn define_array_size() {
+        let mut namespace = Namespace::init();
+        let subscripts = Subscripts::from_raw_indices(&mut namespace, "ij,jk->ik").unwrap();
+        let tt = format_block(super::define_array_size(&subscripts).to_string());
+        insta::assert_snapshot!(tt, @r###"
+        let (n_a, n_b) = arg0.dim();
+        let (_, n_c) = arg1.dim();
+        "###);
+    }
 
     #[test]
     fn function_definition_snapshot() {
@@ -59,6 +125,18 @@ mod test {
             S0: ndarray::Data<Elem = T>,
             S1: ndarray::Data<Elem = T>,
         {
+            let (n_a, n_b) = arg0.dim();
+            let (_, n_c) = arg1.dim();
+            {
+                let (n_0, n_1) = arg0.dim();
+                assert_eq!(n_0, n_a);
+                assert_eq!(n_1, n_b);
+            }
+            {
+                let (n_0, n_1) = arg1.dim();
+                assert_eq!(n_0, n_b);
+                assert_eq!(n_1, n_c);
+            }
             todo!()
         }
         "###);

--- a/einsum-codegen/src/codegen/ndarray/naive.rs
+++ b/einsum-codegen/src/codegen/ndarray/naive.rs
@@ -1,20 +1,12 @@
 //! Generate einsum function with naive loop
 
-#[cfg(doc)]
-use super::function_definition;
-
+use super::*;
 use crate::Subscripts;
-
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use std::collections::HashSet;
 
 fn index_ident(i: char) -> syn::Ident {
     quote::format_ident!("{}", i)
-}
-
-fn n_ident(i: char) -> syn::Ident {
-    quote::format_ident!("n_{}", i)
 }
 
 fn contraction_for(indices: &[char], inner: TokenStream2) -> TokenStream2 {
@@ -78,7 +70,7 @@ fn contraction_inner(subscripts: &Subscripts) -> TokenStream2 {
 /// }
 /// ```
 ///
-pub fn contraction(subscripts: &Subscripts) -> TokenStream2 {
+fn contraction(subscripts: &Subscripts) -> TokenStream2 {
     let mut indices: Vec<char> = subscripts.output.indices();
     for i in subscripts.contraction_indices() {
         indices.push(i);
@@ -88,71 +80,18 @@ pub fn contraction(subscripts: &Subscripts) -> TokenStream2 {
     contraction_for(&indices, inner)
 }
 
-/// Define the index size identifiers, e.g. `n_i`
-pub fn define_array_size(subscripts: &Subscripts) -> TokenStream2 {
-    let mut appeared: HashSet<char> = HashSet::new();
-    let mut tt = Vec::new();
-    for arg in subscripts.inputs.iter() {
-        let n_ident: Vec<syn::Ident> = arg
-            .indices()
-            .into_iter()
-            .map(|i| {
-                if appeared.contains(&i) {
-                    quote::format_ident!("_")
-                } else {
-                    appeared.insert(i);
-                    n_ident(i)
-                }
-            })
-            .collect();
-        tt.push(quote! {
-            let (#(#n_ident),*) = #arg.dim();
-        });
-    }
-    quote! { #(#tt)* }
-}
-
-/// Generate `assert_eq!` to check the size of user input tensors
-pub fn array_size_asserts(subscripts: &Subscripts) -> TokenStream2 {
-    let mut tt = Vec::new();
-    for arg in &subscripts.inputs {
-        // local variable, e.g. `n_2`
-        let n_each: Vec<_> = (0..arg.indices().len())
-            .map(|m| quote::format_ident!("n_{}", m))
-            .collect();
-        // size of index defined previously, e.g. `n_i`
-        let n: Vec<_> = arg.indices().into_iter().map(n_ident).collect();
-        tt.push(quote! {
-            let (#(#n_each),*) = #arg.dim();
-            #(assert_eq!(#n_each, #n);)*
-        });
-    }
-    quote! { #({ #tt })* }
-}
-
-fn define_output_array(subscripts: &Subscripts) -> TokenStream2 {
-    // Define output array
+/// Actual component of einsum [function_definition]
+pub fn naive(subscripts: &Subscripts) -> TokenStream2 {
     let output_ident = &subscripts.output;
-    let mut n_output = Vec::new();
-    for i in subscripts.output.indices() {
-        n_output.push(n_ident(i));
-    }
+    let contraction_tt = contraction(subscripts);
+    let n_output: Vec<_> = subscripts
+        .output
+        .indices()
+        .into_iter()
+        .map(n_ident)
+        .collect();
     quote! {
         let mut #output_ident = ndarray::Array::zeros((#(#n_output),*));
-    }
-}
-
-/// Actual component of einsum [function_definition]
-pub fn inner(subscripts: &Subscripts) -> TokenStream2 {
-    let array_size = define_array_size(subscripts);
-    let array_size_asserts = array_size_asserts(subscripts);
-    let output_ident = &subscripts.output;
-    let output_tt = define_output_array(subscripts);
-    let contraction_tt = contraction(subscripts);
-    quote! {
-        #array_size
-        #array_size_asserts
-        #output_tt
         #contraction_tt
         #output_ident
     }
@@ -163,50 +102,11 @@ mod test {
     use crate::{codegen::format_block, *};
 
     #[test]
-    fn define_array_size() {
+    fn naive() {
         let mut namespace = Namespace::init();
         let subscripts = Subscripts::from_raw_indices(&mut namespace, "ij,jk->ik").unwrap();
-        let tt = format_block(super::define_array_size(&subscripts).to_string());
+        let tt = format_block(super::naive(&subscripts).to_string());
         insta::assert_snapshot!(tt, @r###"
-        let (n_a, n_b) = arg0.dim();
-        let (_, n_c) = arg1.dim();
-        "###);
-    }
-
-    #[test]
-    fn contraction() {
-        let mut namespace = Namespace::init();
-        let subscripts = Subscripts::from_raw_indices(&mut namespace, "ij,jk->ik").unwrap();
-        let tt = format_block(super::contraction(&subscripts).to_string());
-        insta::assert_snapshot!(tt, @r###"
-        for a in 0..n_a {
-            for c in 0..n_c {
-                for b in 0..n_b {
-                    out0[(a, c)] = arg0[(a, b)] * arg1[(b, c)];
-                }
-            }
-        }
-        "###);
-    }
-
-    #[test]
-    fn inner() {
-        let mut namespace = Namespace::init();
-        let subscripts = Subscripts::from_raw_indices(&mut namespace, "ij,jk->ik").unwrap();
-        let tt = format_block(super::inner(&subscripts).to_string());
-        insta::assert_snapshot!(tt, @r###"
-        let (n_a, n_b) = arg0.dim();
-        let (_, n_c) = arg1.dim();
-        {
-            let (n_0, n_1) = arg0.dim();
-            assert_eq!(n_0, n_a);
-            assert_eq!(n_1, n_b);
-        }
-        {
-            let (n_0, n_1) = arg1.dim();
-            assert_eq!(n_0, n_b);
-            assert_eq!(n_1, n_c);
-        }
         let mut out0 = ndarray::Array::zeros((n_a, n_c));
         for a in 0..n_a {
             for c in 0..n_c {

--- a/einsum-derive/src/lib.rs
+++ b/einsum-derive/src/lib.rs
@@ -27,7 +27,7 @@ fn einsum2(input: TokenStream2) -> TokenStream2 {
                 None
             } else {
                 defined.insert(ss.escaped_ident());
-                let inner = naive::inner(ss);
+                let inner = naive(ss);
                 Some(function_definition(ss, inner))
             }
         })


### PR DESCRIPTION
Close #22 

Since einsum subscript has been normalized in #23, we can easily determine a subscript can be replaced by BLAS routines, i.e. `GEMM` is `ab,bc->ac`, `DOT` is `a,a->`, and others are not compatible.